### PR TITLE
0.1.0

### DIFF
--- a/kitura.rb
+++ b/kitura.rb
@@ -1,17 +1,12 @@
-require "language/node"
-
 class Kitura < Formula
   desc "Kitura command-line interface"
   homepage "https://github.com/IBM-Swift/kitura-cli#readme"
-  url "https://registry.npmjs.org/kitura-cli/-/kitura-cli-0.0.16.tgz"
-  version "0.0.16"
-  sha256 "bf43922b76601395b1a86e4050ff9d2b05b33a7b425d24b0d471e5796d5f9af2"
-
-  depends_on "node"
+  url "https://github.com/IBM-Swift/kitura-cli/releases/download/0.1.0/kitura-cli_0.1.0_darwin.tar.gz"
+  version "0.1.0"
+  sha256 "bf8c529cfbfb2fd8a02ba95ff9a1f557d98373ac573f632889a084f0926be844"
 
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install "kitura"
   end
 
   test do


### PR DESCRIPTION
- Update to [kitura-cli 0.1.0](https://github.com/IBM-Swift/kitura-cli/releases/tag/0.1.0)
- Remove Node dependency

Note: `kitura.rb` was generated by the kitura-cli build: https://github.com/IBM-Swift/kitura-cli/releases/download/0.1.0/kitura.rb